### PR TITLE
[ft 008 ] Subject-lecturer-handle-admin-panel-creation

### DIFF
--- a/Backend/controllers/lecturer_assignments_controller.php
+++ b/Backend/controllers/lecturer_assignments_controller.php
@@ -1,0 +1,124 @@
+<?php
+namespace Backend\Controllers;
+
+require_once __DIR__ . '/../services/lecturer_assignments_service.php';
+require_once __DIR__ . '/../utils/route.php';
+
+use Backend\Services\LecturerAssignmentsService;
+use Backend\Utils\Route;
+use Exception;
+
+class LecturerAssignmentsController {
+    private $service;
+
+    public function __construct() {
+        $this->service = new LecturerAssignmentsService();
+    }
+
+    private function getPayload($req) {
+        $payload = $req['body'] ?? [];
+        return is_array($payload) ? $payload : [];
+    }
+
+    private function getAuthUser() {
+        return Route::getInstance()->request['user'] ?? [];
+    }
+
+    private function jsonResponse($status, $message, $data = null) {
+        http_response_code((int)$status);
+        echo json_encode(['status' => (string)$status, 'data' => $data, 'message' => $message]);
+        exit;
+    }
+
+    // ── Responsibilities ──────────────────────────────────────────────
+
+    public function getResponsibilities($req = null, $res = null) {
+        try {
+            $this->jsonResponse('200', 'Responsibilities fetched successfully', $this->service->getResponsibilities());
+        } catch (Exception $e) {
+            error_log('[LecturerAssignmentsController] ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine());
+            $this->jsonResponse('500', 'An internal error occurred');
+        }
+    }
+
+    public function createResponsibility($req = null, $res = null) {
+        try {
+            $payload = $this->getPayload($req);
+            $actor = $this->getAuthUser();
+            $payload['created_by'] = $actor['userName'] ?? '';
+            $payload['updated_by'] = $actor['userName'] ?? '';
+            $this->jsonResponse('200', $this->service->createResponsibility($payload));
+        } catch (Exception $e) {
+            error_log('[LecturerAssignmentsController] ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine());
+            $this->jsonResponse('500', 'An internal error occurred');
+        }
+    }
+
+    public function updateResponsibility($req = null, $res = null) {
+        try {
+            $payload = $this->getPayload($req);
+            $actor = $this->getAuthUser();
+            $payload['updated_by'] = $actor['userName'] ?? '';
+            $this->jsonResponse('200', $this->service->updateResponsibility($payload));
+        } catch (Exception $e) {
+            error_log('[LecturerAssignmentsController] ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine());
+            $this->jsonResponse('500', 'An internal error occurred');
+        }
+    }
+
+    public function deleteResponsibility($req = null, $res = null) {
+        try {
+            $payload = $this->getPayload($req);
+            $this->jsonResponse('200', $this->service->deleteResponsibility($payload['id']));
+        } catch (Exception $e) {
+            error_log('[LecturerAssignmentsController] ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine());
+            $this->jsonResponse('500', 'An internal error occurred');
+        }
+    }
+
+    // ── Assignments ───────────────────────────────────────────────────
+
+    public function getAssignments($req = null, $res = null) {
+        try {
+            $this->jsonResponse('200', 'Assignments fetched successfully', $this->service->getAssignments());
+        } catch (Exception $e) {
+            error_log('[LecturerAssignmentsController] ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine());
+            $this->jsonResponse('500', 'An internal error occurred');
+        }
+    }
+
+    public function createAssignment($req = null, $res = null) {
+        try {
+            $payload = $this->getPayload($req);
+            $actor = $this->getAuthUser();
+            $payload['assigned_by'] = $actor['userName'] ?? '';
+            $this->jsonResponse('200', $this->service->createAssignment($payload));
+        } catch (Exception $e) {
+            error_log('[LecturerAssignmentsController] ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine());
+            $this->jsonResponse('500', 'An internal error occurred');
+        }
+    }
+
+    public function updateAssignment($req = null, $res = null) {
+        try {
+            $payload = $this->getPayload($req);
+            $actor = $this->getAuthUser();
+            $payload['assigned_by'] = $actor['userName'] ?? '';
+            $this->jsonResponse('200', $this->service->updateAssignment($payload));
+        } catch (Exception $e) {
+            error_log('[LecturerAssignmentsController] ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine());
+            $this->jsonResponse('500', 'An internal error occurred');
+        }
+    }
+
+    public function deleteAssignment($req = null, $res = null) {
+        try {
+            $payload = $this->getPayload($req);
+            $this->jsonResponse('200', $this->service->deleteAssignment($payload['id']));
+        } catch (Exception $e) {
+            error_log('[LecturerAssignmentsController] ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine());
+            $this->jsonResponse('500', 'An internal error occurred');
+        }
+    }
+}
+?>

--- a/Backend/middleware/validation.php
+++ b/Backend/middleware/validation.php
@@ -543,5 +543,49 @@ class Validation {
     public function lecturerRequestDelete($req = null, $res = null) {
         $this->deleteById($req, $res);
     }
+
+    // ── Lecturer Responsibility ───────────────────────────────────────
+
+    private function responsibilityRule($requireId = false) {
+        $validator = v::arrayType()
+            ->key('responsibility', v::stringType()->notEmpty()->length(1, 100)->setName('responsibility'));
+
+        if ($requireId) {
+            $validator = $validator->key('id', v::anyOf(v::intVal()->positive(), v::stringType()->regex('/^[1-9][0-9]*$/'))->setName('id'));
+        }
+
+        return $validator;
+    }
+
+    public function responsibilityCreate($req = null, $res = null) {
+        $this->assertPayload($this->getPayload($req), $this->responsibilityRule(false));
+    }
+
+    public function responsibilityUpdate($req = null, $res = null) {
+        $this->assertPayload($this->getPayload($req), $this->responsibilityRule(true));
+    }
+
+    // ── Subject–Lecturer Assignment ───────────────────────────────────
+
+    private function assignmentRule($requireId = false) {
+        $validator = v::arrayType()
+            ->key('subject_cord', v::stringType()->notEmpty()->length(1, 20)->setName('subject_cord'))
+            ->key('lecturer_id', v::anyOf(v::intVal()->positive(), v::stringType()->regex('/^[1-9][0-9]*$/'))->setName('lecturer_id'))
+            ->key('responsibility_id', v::optional(v::anyOf(v::intVal()->positive(), v::stringType()->regex('/^[1-9][0-9]*$/')))->setName('responsibility_id'), false);
+
+        if ($requireId) {
+            $validator = $validator->key('id', v::anyOf(v::intVal()->positive(), v::stringType()->regex('/^[1-9][0-9]*$/'))->setName('id'));
+        }
+
+        return $validator;
+    }
+
+    public function assignmentCreate($req = null, $res = null) {
+        $this->assertPayload($this->getPayload($req), $this->assignmentRule(false));
+    }
+
+    public function assignmentUpdate($req = null, $res = null) {
+        $this->assertPayload($this->getPayload($req), $this->assignmentRule(true));
+    }
 }
 ?>

--- a/Backend/routers/lecturer_assignments_router.php
+++ b/Backend/routers/lecturer_assignments_router.php
@@ -1,0 +1,79 @@
+<?php
+namespace Backend\Routers;
+
+require_once __DIR__ . '/../controllers/lecturer_assignments_controller.php';
+require_once __DIR__ . '/../middleware/validation.php';
+require_once __DIR__ . '/../middleware/jwtToken.php';
+
+use Backend\Controllers\LecturerAssignmentsController;
+use Backend\Middleware\Validation;
+use Backend\Middleware\JwtToken;
+use Backend\Utils\Route;
+
+class LecturerAssignmentsRouter {
+    private $controller;
+    private $router;
+    private $validation;
+
+    public function __construct() {
+        $this->router     = Route::getInstance();
+        $this->controller = new LecturerAssignmentsController();
+        $this->validation = new Validation();
+        $this->registerRoutes();
+        $this->router->dispatch();
+    }
+
+    private function registerRoutes() {
+        $authorMiddleware = function ($req = null, $res = null) {
+            (new JwtToken())->validateToken($req, $res);
+        };
+        $adminMiddleware = JwtToken::requireRole('admin');
+
+        $responsibilityCreateValidation = function ($req = null, $res = null) {
+            $this->validation->responsibilityCreate($req, $res);
+        };
+        $responsibilityUpdateValidation = function ($req = null, $res = null) {
+            $this->validation->responsibilityUpdate($req, $res);
+        };
+        $deleteByIdValidation = function ($req = null, $res = null) {
+            $this->validation->deleteById($req, $res);
+        };
+        $assignmentCreateValidation = function ($req = null, $res = null) {
+            $this->validation->assignmentCreate($req, $res);
+        };
+        $assignmentUpdateValidation = function ($req = null, $res = null) {
+            $this->validation->assignmentUpdate($req, $res);
+        };
+
+        // Responsibilities
+        $this->router->get('/responsibilities', function ($req = null, $res = null) {
+            $this->controller->getResponsibilities($req, $res);
+        });
+        $this->router->post('/responsibilities', [$authorMiddleware, $adminMiddleware, $responsibilityCreateValidation], function ($req = null, $res = null) {
+            $this->controller->createResponsibility($req, $res);
+        });
+        $this->router->post('/responsibilities/update', [$authorMiddleware, $adminMiddleware, $responsibilityUpdateValidation], function ($req = null, $res = null) {
+            $this->controller->updateResponsibility($req, $res);
+        });
+        $this->router->post('/responsibilities/delete', [$authorMiddleware, $adminMiddleware, $deleteByIdValidation], function ($req = null, $res = null) {
+            $this->controller->deleteResponsibility($req, $res);
+        });
+
+        // Assignments
+        $this->router->get('/assignments', function ($req = null, $res = null) {
+            $this->controller->getAssignments($req, $res);
+        });
+        $this->router->post('/assignments', [$authorMiddleware, $adminMiddleware, $assignmentCreateValidation], function ($req = null, $res = null) {
+            $this->controller->createAssignment($req, $res);
+        });
+        $this->router->post('/assignments/update', [$authorMiddleware, $adminMiddleware, $assignmentUpdateValidation], function ($req = null, $res = null) {
+            $this->controller->updateAssignment($req, $res);
+        });
+        $this->router->post('/assignments/delete', [$authorMiddleware, $adminMiddleware, $deleteByIdValidation], function ($req = null, $res = null) {
+            $this->controller->deleteAssignment($req, $res);
+        });
+    }
+}
+
+new LecturerAssignmentsRouter;
+?>

--- a/Backend/seeds/laboratory_schedule_system.sql
+++ b/Backend/seeds/laboratory_schedule_system.sql
@@ -92,6 +92,21 @@ CREATE TABLE `lecturer_requests` (
 -- --------------------------------------------------------
 
 --
+-- Table structure for table `lecturer_responsibility`
+--
+
+CREATE TABLE `lecturer_responsibility` (
+  `id` int(11) NOT NULL,
+  `responsibility` varchar(100) NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT current_timestamp(),
+  `updated_at` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  `created_by` varchar(100) NOT NULL,
+  `updated_by` varchar(100) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+
+--
 -- Table structure for table `lecture_groups`
 --
 
@@ -166,6 +181,7 @@ CREATE TABLE `subject_lecture_relations` (
   `id` int(11) NOT NULL,
   `subject_cord` varchar(20) NOT NULL,
   `lecturer_id` int(11) NOT NULL,
+  `responsibility_id` int(11) DEFAULT NULL,
   `assigned_by` varchar(50) DEFAULT NULL,
   `assigned_at` timestamp NOT NULL DEFAULT current_timestamp()
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
@@ -365,6 +381,13 @@ ALTER TABLE `lecturer_requests`
   ADD KEY `fk_request_lecture_group` (`lecture_group_id`);
 
 --
+-- Indexes for table `lecturer_responsibility`
+--
+ALTER TABLE `lecturer_responsibility`
+  ADD PRIMARY KEY (`id`),
+  ADD UNIQUE KEY `responsibility` (`responsibility`);
+
+--
 -- Indexes for table `lecture_groups`
 --
 ALTER TABLE `lecture_groups`
@@ -401,7 +424,8 @@ ALTER TABLE `subject_group_relations`
 ALTER TABLE `subject_lecture_relations`
   ADD PRIMARY KEY (`id`),
   ADD KEY `subject_cord` (`subject_cord`),
-  ADD KEY `lecturer_id` (`lecturer_id`);
+  ADD KEY `lecturer_id` (`lecturer_id`),
+  ADD KEY `fk_subject_lecturer_responsibility` (`responsibility_id`);
 
 --
 -- Indexes for table `temporary_timetable`
@@ -494,6 +518,12 @@ ALTER TABLE `labs`
 --
 ALTER TABLE `lecturer_requests`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=20;
+
+--
+-- AUTO_INCREMENT for table `lecturer_responsibility`
+--
+ALTER TABLE `lecturer_responsibility`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=6;
 
 --
 -- AUTO_INCREMENT for table `lecture_groups`
@@ -626,6 +656,7 @@ ALTER TABLE `subject_group_relations`
 -- Constraints for table `subject_lecture_relations`
 --
 ALTER TABLE `subject_lecture_relations`
+  ADD CONSTRAINT `fk_subject_lecturer_responsibility` FOREIGN KEY (`responsibility_id`) REFERENCES `lecturer_responsibility` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
   ADD CONSTRAINT `subject_lecture_relations_ibfk_1` FOREIGN KEY (`subject_cord`) REFERENCES `practical_subjects` (`subject_cord`) ON DELETE CASCADE,
   ADD CONSTRAINT `subject_lecture_relations_ibfk_2` FOREIGN KEY (`lecturer_id`) REFERENCES `users` (`id`) ON DELETE CASCADE;
 

--- a/Backend/server.php
+++ b/Backend/server.php
@@ -45,6 +45,7 @@ class Server {
             $router->accessEndpoint('/api/v1/timetable', 'routers/timetable_router.php');
             $router->accessEndpoint('/api/v1/lecturer-request', 'routers/lecturer_requests_router.php');
             $router->accessEndpoint('/api/v1/news', 'routers/news_router.php');
+            $router->accessEndpoint('/api/v1/lecturer-assignment', 'routers/lecturer_assignments_router.php');
             http_response_code(404);
             echo json_encode(['status' => '404', 'message' => 'Endpoint not found']);
             exit;

--- a/Backend/services/lecturer_assignments_service.php
+++ b/Backend/services/lecturer_assignments_service.php
@@ -1,0 +1,153 @@
+<?php
+namespace Backend\Services;
+
+require_once __DIR__ . '/../DB/dbConnection.php';
+
+use Backend\DB\DbConnection;
+use Exception;
+
+class LecturerAssignmentsService {
+
+    private function fetchAllRows($query, $property = null) {
+        $DB_CON = new DbConnection();
+        if ($property === null) {
+            $DB_CON->selectData($query);
+        } else {
+            $DB_CON->selectDataByProperty($query, $property);
+        }
+        $result = $DB_CON->fetchAll();
+        if ($result === false) {
+            throw new Exception($DB_CON->getError() ?: 'SQL query error');
+        }
+        return $result;
+    }
+
+    private function executeQuery($query, $property) {
+        $DB_CON = new DbConnection();
+        $result = $DB_CON->execute($query, $property);
+        if ($result === false) {
+            throw new Exception($DB_CON->getError() ?: 'SQL query error');
+        }
+        return $result;
+    }
+
+    // ── Responsibilities ──────────────────────────────────────────────
+
+    public function getResponsibilities() {
+        return $this->fetchAllRows(
+            "SELECT id, responsibility, created_by, updated_by, created_at, updated_at
+             FROM lecturer_responsibility
+             ORDER BY responsibility ASC"
+        );
+    }
+
+    public function createResponsibility($payload) {
+        $this->executeQuery(
+            "INSERT INTO lecturer_responsibility (responsibility, created_by, updated_by)
+             VALUES (:responsibility, :created_by, :updated_by)",
+            [
+                'responsibility' => $payload['responsibility'],
+                'created_by'     => $payload['created_by'] ?? '',
+                'updated_by'     => $payload['updated_by'] ?? '',
+            ]
+        );
+        return 'Responsibility created successfully';
+    }
+
+    public function updateResponsibility($payload) {
+        $this->executeQuery(
+            "UPDATE lecturer_responsibility
+             SET responsibility = :responsibility,
+                 updated_by     = :updated_by
+             WHERE id = :id",
+            [
+                'id'             => $payload['id'],
+                'responsibility' => $payload['responsibility'],
+                'updated_by'     => $payload['updated_by'] ?? '',
+            ]
+        );
+        return 'Responsibility updated successfully';
+    }
+
+    public function deleteResponsibility($id) {
+        $this->executeQuery(
+            "DELETE FROM lecturer_responsibility WHERE id = :id",
+            ['id' => $id]
+        );
+        return 'Responsibility deleted successfully';
+    }
+
+    // ── Subject–Lecturer Assignments ──────────────────────────────────
+
+    public function getAssignments() {
+        return $this->fetchAllRows(
+            "SELECT
+                slr.id,
+                slr.subject_cord,
+                slr.lecturer_id,
+                slr.responsibility_id,
+                slr.assigned_by,
+                slr.assigned_at,
+                ps.subject                                                AS subject_name,
+                y.year                                                    AS year,
+                TRIM(CONCAT(COALESCE(u.honorifics,''), ' ',
+                            u.first_name, ' ', u.last_name))              AS lecturer_name,
+                u.initials                                                AS lecturer_initials,
+                lr.responsibility                                         AS responsibility_name
+             FROM subject_lecture_relations slr
+             LEFT JOIN practical_subjects ps ON slr.subject_cord = ps.subject_cord
+             LEFT JOIN years y               ON ps.year_id = y.id
+             LEFT JOIN users u               ON slr.lecturer_id = u.id
+             LEFT JOIN lecturer_responsibility lr ON slr.responsibility_id = lr.id
+             ORDER BY ps.year_id ASC, slr.subject_cord ASC, u.last_name ASC"
+        );
+    }
+
+    public function createAssignment($payload) {
+        $responsibilityId = !empty($payload['responsibility_id']) ? (int)$payload['responsibility_id'] : null;
+
+        $this->executeQuery(
+            "INSERT INTO subject_lecture_relations
+                (subject_cord, lecturer_id, responsibility_id, assigned_by)
+             VALUES
+                (:subject_cord, :lecturer_id, :responsibility_id, :assigned_by)",
+            [
+                'subject_cord'      => $payload['subject_cord'],
+                'lecturer_id'       => (int)$payload['lecturer_id'],
+                'responsibility_id' => $responsibilityId,
+                'assigned_by'       => $payload['assigned_by'] ?? '',
+            ]
+        );
+        return 'Assignment created successfully';
+    }
+
+    public function updateAssignment($payload) {
+        $responsibilityId = !empty($payload['responsibility_id']) ? (int)$payload['responsibility_id'] : null;
+
+        $this->executeQuery(
+            "UPDATE subject_lecture_relations
+             SET subject_cord      = :subject_cord,
+                 lecturer_id       = :lecturer_id,
+                 responsibility_id = :responsibility_id,
+                 assigned_by       = :assigned_by
+             WHERE id = :id",
+            [
+                'id'                => $payload['id'],
+                'subject_cord'      => $payload['subject_cord'],
+                'lecturer_id'       => (int)$payload['lecturer_id'],
+                'responsibility_id' => $responsibilityId,
+                'assigned_by'       => $payload['assigned_by'] ?? '',
+            ]
+        );
+        return 'Assignment updated successfully';
+    }
+
+    public function deleteAssignment($id) {
+        $this->executeQuery(
+            "DELETE FROM subject_lecture_relations WHERE id = :id",
+            ['id' => $id]
+        );
+        return 'Assignment deleted successfully';
+    }
+}
+?>

--- a/Frontend/API/lecturerAssignmentsApi.js
+++ b/Frontend/API/lecturerAssignmentsApi.js
@@ -1,0 +1,90 @@
+const BASE_URL = 'http://localhost/LaboratoryScheduleSystemWebsite/Backend/api/v1/lecturer-assignment';
+
+const getResponsibilities = async () => {
+    const response = await fetch(`${BASE_URL}/responsibilities`, {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+    });
+    return response.json();
+};
+
+const createResponsibility = async (payload) => {
+    const response = await fetch(`${BASE_URL}/responsibilities`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(payload),
+    });
+    return response.json();
+};
+
+const updateResponsibility = async (payload) => {
+    const response = await fetch(`${BASE_URL}/responsibilities/update`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(payload),
+    });
+    return response.json();
+};
+
+const deleteResponsibility = async (id) => {
+    const response = await fetch(`${BASE_URL}/responsibilities/delete`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ id }),
+    });
+    return response.json();
+};
+
+const getAssignments = async () => {
+    const response = await fetch(`${BASE_URL}/assignments`, {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+    });
+    return response.json();
+};
+
+const createAssignment = async (payload) => {
+    const response = await fetch(`${BASE_URL}/assignments`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(payload),
+    });
+    return response.json();
+};
+
+const updateAssignment = async (payload) => {
+    const response = await fetch(`${BASE_URL}/assignments/update`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(payload),
+    });
+    return response.json();
+};
+
+const deleteAssignment = async (id) => {
+    const response = await fetch(`${BASE_URL}/assignments/delete`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ id }),
+    });
+    return response.json();
+};
+
+export {
+    getResponsibilities,
+    createResponsibility,
+    updateResponsibility,
+    deleteResponsibility,
+    getAssignments,
+    createAssignment,
+    updateAssignment,
+    deleteAssignment,
+};

--- a/Frontend/JS/admin.js
+++ b/Frontend/JS/admin.js
@@ -1,4 +1,5 @@
 import { getTimetableData, getSubjectCodes, getYears, createYear, updateYear, deleteYear, getTimeSlots, getColumnHeadings, getTimetableSettings, getLectureGroups, createLectureGroup, updateLectureGroup, deleteLectureGroup, getLabs, createLab, updateLab, deleteLab, getTimetableCells, createTimetableRecord, updateTimetableRecord, deleteTimetableRecord, updateTimetableSettings, resetTimetableSettings, createColumnHeading, updateColumnHeading, deleteColumnHeading, createTimeSlot, updateTimeSlot, deleteTimeSlot, createSubject, updateSubject, deleteSubject } from '../API/timetableApi.js';
+import { getResponsibilities, createResponsibility, updateResponsibility, deleteResponsibility, getAssignments, createAssignment, updateAssignment, deleteAssignment } from '../API/lecturerAssignmentsApi.js';
 import { getLecturerRequests, updateLecturerRequest, checkLecturerRequestAvailability, deleteLecturerRequest } from '../API/lecturerRequestApi.js';
 import { getNews, createNews, updateNews, deleteNews } from '../API/newsApi.js';
 import { getUsers, createUser, updateUser, deleteUser, resetUserPassword } from '../API/userApi.js';
@@ -336,6 +337,8 @@ const initAdminPanel = async () => {
         newsItems: [],
         subjects: [],
         users: [],
+        responsibilities: [],
+        assignments: [],
     };
 
     const buildCard = (label, value, themeClass = 'bg-white text-gray-950') => `
@@ -888,6 +891,12 @@ const initAdminPanel = async () => {
     };
 
     const renderAdminPanel = () => {
+        // Make adminState accessible to the assignments sub-panel
+        window.__adminStateRef = adminState;
+        if (typeof window.__renderLecturerAssignments === 'function') {
+            window.__renderLecturerAssignments(adminState);
+        }
+
         const {
             timetableSettings,
             timeSlots,
@@ -1270,6 +1279,8 @@ const initAdminPanel = async () => {
             lectureGroupsResponse,
             labsResponse,
             timetableCellsResponse,
+            responsibilitiesResponse,
+            assignmentsResponse,
         ] = await Promise.all([
             getTimetableSettings(),
             getTimeSlots(),
@@ -1283,6 +1294,8 @@ const initAdminPanel = async () => {
             getLectureGroups(),
             getLabs(),
             getTimetableCells(),
+            getResponsibilities(),
+            getAssignments(),
         ]);
 
         adminState.timetableSettings = settingsResponse.status === '200' ? settingsResponse.data : null;
@@ -1296,9 +1309,9 @@ const initAdminPanel = async () => {
         adminState.newsItems = newsResponse.status === '200' && Array.isArray(newsResponse.data) ? newsResponse.data : [];
         adminState.subjects = subjectsResponse.status === '200' && Array.isArray(subjectsResponse.data) ? subjectsResponse.data : [];
         adminState.years = yearsResponse.status === '200' && Array.isArray(yearsResponse.data) ? yearsResponse.data : [];
-        adminState.users = usersResponse.status === '200' && Array.isArray(usersResponse.data)
-            ? usersResponse.data
-            : [];
+        adminState.users = usersResponse.status === '200' && Array.isArray(usersResponse.data) ? usersResponse.data : [];
+        adminState.responsibilities = responsibilitiesResponse.status === '200' && Array.isArray(responsibilitiesResponse.data) ? responsibilitiesResponse.data : [];
+        adminState.assignments = assignmentsResponse.status === '200' && Array.isArray(assignmentsResponse.data) ? assignmentsResponse.data : [];
 
         fullTimetableSettingsData = adminState.timetableSettings;
         fullTimeSlotsData = adminState.timeSlots;
@@ -2190,4 +2203,315 @@ const initAdminPanel = async () => {
  * Logged users can open scheduling-form from lecturer-request button.
  */
 
-export { initAdminSideNav, initAdminPanel };
+const initLecturerAssignmentsPanel = () => {
+    // ── DOM references ────────────────────────────────────────────────
+    const responsibilitiesContainer   = document.getElementById('admin-responsibilities-list');
+    const assignmentsContainer        = document.getElementById('admin-assignments-list');
+    const responsibilityCreateButton  = document.getElementById('admin-responsibility-create-btn');
+    const assignmentCreateButton      = document.getElementById('admin-assignment-create-btn');
+
+    const responsibilityFormModal     = document.getElementById('admin-responsibility-form-modal');
+    const responsibilityForm          = document.getElementById('admin-responsibility-form');
+    const responsibilityFormTitle     = document.getElementById('admin-responsibility-form-title');
+    const responsibilityFormClose     = document.getElementById('admin-responsibility-form-close');
+    const responsibilityFormCancel    = document.getElementById('admin-responsibility-form-cancel');
+    const responsibilityIdInput       = document.getElementById('admin-responsibility-id');
+    const responsibilityNameInput     = document.getElementById('admin-responsibility-name');
+
+    const assignmentFormModal         = document.getElementById('admin-assignment-form-modal');
+    const assignmentForm              = document.getElementById('admin-assignment-form');
+    const assignmentFormTitle         = document.getElementById('admin-assignment-form-title');
+    const assignmentFormClose         = document.getElementById('admin-assignment-form-close');
+    const assignmentFormCancel        = document.getElementById('admin-assignment-form-cancel');
+    const assignmentIdInput           = document.getElementById('admin-assignment-id');
+    const assignmentSubjectSelect     = document.getElementById('admin-assignment-subject');
+    const assignmentLecturerSelect    = document.getElementById('admin-assignment-lecturer');
+    const assignmentResponsibilitySelect = document.getElementById('admin-assignment-responsibility');
+
+    if (!responsibilitiesContainer || !assignmentsContainer || !responsibilityCreateButton
+        || !assignmentCreateButton || !responsibilityFormModal || !responsibilityForm
+        || !assignmentFormModal || !assignmentForm) {
+        return;
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────
+    const showModal  = (el) => { el.classList.remove('hidden'); document.body.classList.add('overflow-hidden'); el.scrollTop = 0; };
+    const hideModal  = (el) => { el.classList.add('hidden'); if (!document.querySelector('.fixed:not(.hidden)')) document.body.classList.remove('overflow-hidden'); };
+
+    const populateSelect = (selectEl, items, valueKey, labelKey, emptyLabel = 'Select') => {
+        const current = selectEl.value;
+        selectEl.innerHTML = `<option value="">${escapeHtml(emptyLabel)}</option>`
+            + items.map(item => `<option value="${escapeHtml(String(item[valueKey] || ''))}">${escapeHtml(String(item[labelKey] || ''))}</option>`).join('');
+        if (current) selectEl.value = current;
+    };
+
+    const getLecturers = () => {
+        const adminStateEl = document.getElementById('admin-assignments-list');
+        if (!adminStateEl) return [];
+        return window.__adminState?.users?.filter(u => u.role === 'lecturer') ?? [];
+    };
+
+    // ── Render responsibilities ───────────────────────────────────────
+    const renderResponsibilities = (items) => {
+        if (!responsibilitiesContainer) return;
+        if (!items.length) {
+            responsibilitiesContainer.innerHTML = `<div class="bg-gray-100 rounded-lg px-4 py-6 text-gray-500 font-bold text-center">No responsibilities defined yet.</div>`;
+            return;
+        }
+        responsibilitiesContainer.innerHTML = `
+            <table class="w-full text-sm text-left">
+                <thead class="bg-gray-100 uppercase text-gray-600">
+                    <tr>
+                        <th class="px-4 py-3">Responsibility</th>
+                        <th class="px-4 py-3">Created By</th>
+                        <th class="px-4 py-3">Action</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    ${items.map(item => `
+                        <tr class="border-b border-gray-200">
+                            <td class="px-4 py-3 font-bold">${escapeHtml(item.responsibility || '-')}</td>
+                            <td class="px-4 py-3 text-gray-500">${escapeHtml(item.created_by || '-')}</td>
+                            <td class="px-4 py-3">
+                                <div class="flex flex-wrap gap-2">
+                                    <button type="button" data-responsibility-action="update" data-responsibility-id="${escapeHtml(item.id)}" class="bg-sky-600 text-white px-3 py-2 rounded-lg font-black hover:bg-sky-700">Update</button>
+                                    <button type="button" data-responsibility-action="delete" data-responsibility-id="${escapeHtml(item.id)}" class="bg-red-600 text-white px-3 py-2 rounded-lg font-black hover:bg-red-700">Delete</button>
+                                </div>
+                            </td>
+                        </tr>
+                    `).join('')}
+                </tbody>
+            </table>`;
+    };
+
+    // ── Render assignments ────────────────────────────────────────────
+    const renderAssignments = (items) => {
+        if (!assignmentsContainer) return;
+        if (!items.length) {
+            assignmentsContainer.innerHTML = `<div class="bg-gray-100 rounded-lg px-4 py-6 text-gray-500 font-bold text-center">No assignments yet. Use the button above to assign a lecturer to a subject.</div>`;
+            return;
+        }
+        assignmentsContainer.innerHTML = `
+            <table class="w-full text-sm text-left">
+                <thead class="bg-gray-100 uppercase text-gray-600">
+                    <tr>
+                        <th class="px-4 py-3">Year</th>
+                        <th class="px-4 py-3">Subject Code</th>
+                        <th class="px-4 py-3">Subject Name</th>
+                        <th class="px-4 py-3">Lecturer</th>
+                        <th class="px-4 py-3">Responsibility</th>
+                        <th class="px-4 py-3">Assigned By</th>
+                        <th class="px-4 py-3">Action</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    ${items.map(item => `
+                        <tr class="border-b border-gray-200 align-top">
+                            <td class="px-4 py-3">${escapeHtml(item.year || '-')}</td>
+                            <td class="px-4 py-3 font-bold">${escapeHtml(item.subject_cord || '-')}</td>
+                            <td class="px-4 py-3">${escapeHtml(item.subject_name || '-')}</td>
+                            <td class="px-4 py-3 font-bold">${escapeHtml(item.lecturer_name || '-')}</td>
+                            <td class="px-4 py-3">${item.responsibility_name
+                                ? `<span class="px-3 py-1 rounded-full text-xs font-black bg-sky-100 text-sky-700">${escapeHtml(item.responsibility_name)}</span>`
+                                : '<span class="text-gray-400">—</span>'}</td>
+                            <td class="px-4 py-3 text-gray-500">${escapeHtml(item.assigned_by || '-')}</td>
+                            <td class="px-4 py-3">
+                                <div class="flex flex-wrap gap-2">
+                                    <button type="button" data-assignment-action="update" data-assignment-id="${escapeHtml(item.id)}" class="bg-sky-600 text-white px-3 py-2 rounded-lg font-black hover:bg-sky-700">Update</button>
+                                    <button type="button" data-assignment-action="delete" data-assignment-id="${escapeHtml(item.id)}" class="bg-red-600 text-white px-3 py-2 rounded-lg font-black hover:bg-red-700">Delete</button>
+                                </div>
+                            </td>
+                        </tr>
+                    `).join('')}
+                </tbody>
+            </table>`;
+    };
+
+    // ── Responsibility form open/close ────────────────────────────────
+    const resetResponsibilityForm = () => {
+        responsibilityForm.reset();
+        responsibilityIdInput.value = '';
+        responsibilityFormTitle.textContent = 'New Responsibility';
+    };
+
+    const openResponsibilityForm = (record = null) => {
+        resetResponsibilityForm();
+        if (record) {
+            responsibilityFormTitle.textContent = 'Update Responsibility';
+            responsibilityIdInput.value = record.id || '';
+            responsibilityNameInput.value = record.responsibility || '';
+        }
+        showModal(responsibilityFormModal);
+    };
+
+    const hideResponsibilityForm = () => {
+        hideModal(responsibilityFormModal);
+        resetResponsibilityForm();
+    };
+
+    // ── Assignment form open/close ────────────────────────────────────
+    const resetAssignmentForm = () => {
+        assignmentForm.reset();
+        assignmentIdInput.value = '';
+        assignmentFormTitle.textContent = 'New Assignment';
+    };
+
+    const openAssignmentForm = (record = null, state) => {
+        resetAssignmentForm();
+
+        populateSelect(assignmentSubjectSelect, state.subjects, 'subject_cord',
+            item => `${item.subject_cord} — ${item.subject}`, 'Select subject');
+        assignmentSubjectSelect.innerHTML = `<option value="">Select subject</option>`
+            + state.subjects.map(s => `<option value="${escapeHtml(s.subject_cord)}">${escapeHtml(s.subject_cord + ' — ' + s.subject + (s.year ? ' (' + s.year + ')' : ''))}</option>`).join('');
+
+        const lecturers = (state.users || []).filter(u => u.role === 'lecturer');
+        assignmentLecturerSelect.innerHTML = `<option value="">Select lecturer</option>`
+            + lecturers.map(u => `<option value="${escapeHtml(String(u.id))}">${escapeHtml(u.lecturer_name || (u.first_name + ' ' + u.last_name))}</option>`).join('');
+
+        assignmentResponsibilitySelect.innerHTML = `<option value="">No responsibility (optional)</option>`
+            + state.responsibilities.map(r => `<option value="${escapeHtml(String(r.id))}">${escapeHtml(r.responsibility)}</option>`).join('');
+
+        if (record) {
+            assignmentFormTitle.textContent = 'Update Assignment';
+            assignmentIdInput.value = record.id || '';
+            assignmentSubjectSelect.value = record.subject_cord || '';
+            assignmentLecturerSelect.value = String(record.lecturer_id || '');
+            assignmentResponsibilitySelect.value = String(record.responsibility_id || '');
+        }
+        showModal(assignmentFormModal);
+    };
+
+    const hideAssignmentForm = () => {
+        hideModal(assignmentFormModal);
+        resetAssignmentForm();
+    };
+
+    // ── Reload helper (updates both containers) ───────────────────────
+    const reloadAssignmentData = async (state) => {
+        try {
+            const [rRes, aRes] = await Promise.all([getResponsibilities(), getAssignments()]);
+            state.responsibilities = rRes.status === '200' && Array.isArray(rRes.data) ? rRes.data : state.responsibilities;
+            state.assignments      = aRes.status === '200' && Array.isArray(aRes.data) ? aRes.data : state.assignments;
+        } catch (_) { /* non-critical */ }
+        renderResponsibilities(state.responsibilities);
+        renderAssignments(state.assignments);
+    };
+
+    // ── Event: nav buttons already bound; expose render for initial load ──
+    // Called from renderAdminPanel in the main init block — we attach a hook below.
+    window.__renderLecturerAssignments = (state) => {
+        renderResponsibilities(state.responsibilities);
+        renderAssignments(state.assignments);
+    };
+
+    // ── Responsibility form submit ─────────────────────────────────────
+    responsibilityCreateButton.addEventListener('click', () => openResponsibilityForm());
+    responsibilityFormClose.addEventListener('click',  hideResponsibilityForm);
+    responsibilityFormCancel.addEventListener('click', hideResponsibilityForm);
+
+    responsibilityForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const payload = {
+            id:             responsibilityIdInput.value || '',
+            responsibility: responsibilityNameInput.value.trim(),
+        };
+        try {
+            const result = payload.id
+                ? await updateResponsibility(payload)
+                : await createResponsibility(payload);
+
+            if (result.status !== '200') {
+                window.alert(result.message || 'Failed to save responsibility.');
+                return;
+            }
+            window.alert(result.message || 'Responsibility saved.');
+            hideResponsibilityForm();
+            const state = window.__adminStateRef;
+            if (state) await reloadAssignmentData(state);
+        } catch (err) {
+            window.alert(err.message || 'Failed to save responsibility.');
+        }
+    });
+
+    responsibilitiesContainer.addEventListener('click', async (e) => {
+        const btn = e.target.closest('[data-responsibility-action]');
+        if (!btn) return;
+        const id     = btn.getAttribute('data-responsibility-id') || '';
+        const action = btn.getAttribute('data-responsibility-action') || '';
+        const state  = window.__adminStateRef;
+        const record = state?.responsibilities.find(r => String(r.id) === String(id));
+        if (!record) return;
+
+        if (action === 'update') { openResponsibilityForm(record); return; }
+
+        if (!window.confirm('Delete this responsibility? Assignments using it will lose their responsibility link.')) return;
+        try {
+            const result = await deleteResponsibility(id);
+            window.alert(result.message || 'Responsibility deleted.');
+            if (state) await reloadAssignmentData(state);
+        } catch (err) {
+            window.alert(err.message || 'Failed to delete responsibility.');
+        }
+    });
+
+    // ── Assignment form submit ────────────────────────────────────────
+    assignmentCreateButton.addEventListener('click', () => openAssignmentForm(null, window.__adminStateRef || { subjects: [], users: [], responsibilities: [] }));
+    assignmentFormClose.addEventListener('click',  hideAssignmentForm);
+    assignmentFormCancel.addEventListener('click', hideAssignmentForm);
+
+    assignmentForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const payload = {
+            id:                assignmentIdInput.value || '',
+            subject_cord:      assignmentSubjectSelect.value || '',
+            lecturer_id:       assignmentLecturerSelect.value || '',
+            responsibility_id: assignmentResponsibilitySelect.value || '',
+        };
+
+        if (!payload.subject_cord) { window.alert('Please select a subject.'); return; }
+        if (!payload.lecturer_id)  { window.alert('Please select a lecturer.'); return; }
+
+        try {
+            const result = payload.id
+                ? await updateAssignment(payload)
+                : await createAssignment(payload);
+
+            if (result.status !== '200') {
+                window.alert(result.message || 'Failed to save assignment.');
+                return;
+            }
+            window.alert(result.message || 'Assignment saved.');
+            hideAssignmentForm();
+            const state = window.__adminStateRef;
+            if (state) await reloadAssignmentData(state);
+        } catch (err) {
+            window.alert(err.message || 'Failed to save assignment.');
+        }
+    });
+
+    assignmentsContainer.addEventListener('click', async (e) => {
+        const btn = e.target.closest('[data-assignment-action]');
+        if (!btn) return;
+        const id     = btn.getAttribute('data-assignment-id') || '';
+        const action = btn.getAttribute('data-assignment-action') || '';
+        const state  = window.__adminStateRef;
+        const record = state?.assignments.find(a => String(a.id) === String(id));
+        if (!record) return;
+
+        if (action === 'update') {
+            openAssignmentForm(record, state || { subjects: [], users: [], responsibilities: [] });
+            return;
+        }
+
+        if (!window.confirm('Delete this assignment?')) return;
+        try {
+            const result = await deleteAssignment(id);
+            window.alert(result.message || 'Assignment deleted.');
+            if (state) await reloadAssignmentData(state);
+        } catch (err) {
+            window.alert(err.message || 'Failed to delete assignment.');
+        }
+    });
+};
+
+export { initAdminSideNav, initAdminPanel, initLecturerAssignmentsPanel };

--- a/Frontend/JS/main.js
+++ b/Frontend/JS/main.js
@@ -1,5 +1,5 @@
 import { initTimetablePage } from './timetable.js';
-import { initAdminPanel, initAdminSideNav } from './admin.js';
+import { initAdminPanel, initAdminSideNav, initLecturerAssignmentsPanel } from './admin.js';
 import { initNewsPage } from './news.js';
 import { initLoginForm } from './login.js';
 import { initAuthNavButton } from './loginUser.js';
@@ -13,5 +13,6 @@ initLoadingSystem();
     initNewsPage,
     initAdminSideNav,
     initAdminPanel,
+    initLecturerAssignmentsPanel,
     initTimetablePage,
 ].forEach((initializer) => initializer());

--- a/Frontend/Pages/AdminPanel/admin.php
+++ b/Frontend/Pages/AdminPanel/admin.php
@@ -28,6 +28,8 @@
                         <button type="button" data-admin-target="admin-labs" class="admin-nav-btn bg-gray-100 hover:bg-sky-100 rounded-lg px-4 py-3 text-left">Labs</button>
                         <button type="button" data-admin-target="admin-subjects" class="admin-nav-btn bg-gray-100 hover:bg-sky-100 rounded-lg px-4 py-3 text-left">Subjects</button>
                         <button type="button" data-admin-target="admin-users" class="admin-nav-btn bg-gray-100 hover:bg-sky-100 rounded-lg px-4 py-3 text-left">Users</button>
+                        <button type="button" data-admin-target="admin-responsibilities" class="admin-nav-btn bg-gray-100 hover:bg-sky-100 rounded-lg px-4 py-3 text-left">Responsibilities</button>
+                        <button type="button" data-admin-target="admin-assignments" class="admin-nav-btn bg-gray-100 hover:bg-sky-100 rounded-lg px-4 py-3 text-left">Lecturer Assignments</button>
                     </nav>
                 </aside>
 
@@ -181,6 +183,30 @@
                             <button id="admin-user-create-btn" type="button" class="bg-emerald-600 text-white font-black px-4 py-3 rounded-lg hover:bg-emerald-700">New User</button>
                         </div>
                         <div id="admin-users-list" class="pt-5 overflow-x-auto"></div>
+                    </section>
+
+                    <section id="admin-responsibilities" data-admin-section class="hidden bg-white/92 rounded-lg p-5 shadow-lg lg:h-[calc(100svh-10rem)] lg:overflow-y-auto">
+                        <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+                            <div>
+                                <p class="text-sm uppercase tracking-[0.25em] text-gray-500 font-black">Responsibilities</p>
+                                <h2 class="text-2xl font-black">Manage Lecturer Responsibilities</h2>
+                                <p class="pt-2 text-sm text-gray-600">Define responsibility types that can be assigned to lecturers (e.g. Lab In-Charge, Demonstrator).</p>
+                            </div>
+                            <button id="admin-responsibility-create-btn" type="button" class="bg-sky-600 text-white font-black px-4 py-3 rounded-lg hover:bg-sky-700">New Responsibility</button>
+                        </div>
+                        <div id="admin-responsibilities-list" class="pt-5 overflow-x-auto"></div>
+                    </section>
+
+                    <section id="admin-assignments" data-admin-section class="hidden bg-white/92 rounded-lg p-5 shadow-lg lg:h-[calc(100svh-10rem)] lg:overflow-y-auto">
+                        <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+                            <div>
+                                <p class="text-sm uppercase tracking-[0.25em] text-gray-500 font-black">Lecturer Assignments</p>
+                                <h2 class="text-2xl font-black">Assign Lecturers to Subjects</h2>
+                                <p class="pt-2 text-sm text-gray-600">Link lecturers to practical subjects and optionally set their responsibility type.</p>
+                            </div>
+                            <button id="admin-assignment-create-btn" type="button" class="bg-sky-600 text-white font-black px-4 py-3 rounded-lg hover:bg-sky-700">New Assignment</button>
+                        </div>
+                        <div id="admin-assignments-list" class="pt-5 overflow-x-auto"></div>
                     </section>
                 </div>
             </section>
@@ -508,6 +534,52 @@
                 </div>
             </form>
         </section>
+        <!-- Responsibility form modal -->
+        <section id="admin-responsibility-form-modal" class="hidden fixed inset-0 bg-gray-950/50 z-30 overflow-y-auto p-4">
+            <form id="admin-responsibility-form" class="w-full max-w-2xl bg-white rounded-lg p-5 shadow-2xl grid grid-cols-1 gap-4 my-8 mx-auto">
+                <div class="flex items-start justify-between gap-4">
+                    <div>
+                        <p class="text-sm uppercase tracking-[0.25em] text-gray-500 font-black">Responsibility</p>
+                        <h3 id="admin-responsibility-form-title" class="text-2xl font-black">New Responsibility</h3>
+                    </div>
+                    <button type="button" id="admin-responsibility-form-close" class="self-start bg-red-500 p-1 w-8 rounded-sm font-bold text-white active:scale-95" aria-label="Close">X</button>
+                </div>
+                <input type="hidden" id="admin-responsibility-id">
+                <input type="text" id="admin-responsibility-name" placeholder="Responsibility name (e.g. Lab In-Charge)" class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3" required>
+                <div class="flex gap-3 justify-end">
+                    <button id="admin-responsibility-form-cancel" type="button" class="bg-gray-200 text-gray-900 font-black px-5 py-3 rounded-lg hover:bg-gray-300">Cancel</button>
+                    <button type="submit" class="bg-gray-950 text-white font-black px-5 py-3 rounded-lg hover:bg-sky-700">Save Responsibility</button>
+                </div>
+            </form>
+        </section>
+
+        <!-- Assignment form modal -->
+        <section id="admin-assignment-form-modal" class="hidden fixed inset-0 bg-gray-950/50 z-30 overflow-y-auto p-4">
+            <form id="admin-assignment-form" class="w-full max-w-3xl bg-white rounded-lg p-5 shadow-2xl grid grid-cols-1 md:grid-cols-2 gap-4 my-8 mx-auto">
+                <div class="md:col-span-2 flex items-start justify-between gap-4">
+                    <div>
+                        <p class="text-sm uppercase tracking-[0.25em] text-gray-500 font-black">Lecturer Assignment</p>
+                        <h3 id="admin-assignment-form-title" class="text-2xl font-black">New Assignment</h3>
+                    </div>
+                    <button type="button" id="admin-assignment-form-close" class="self-start bg-red-500 p-1 w-8 rounded-sm font-bold text-white active:scale-95" aria-label="Close">X</button>
+                </div>
+                <input type="hidden" id="admin-assignment-id">
+                <select id="admin-assignment-subject" class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3" required>
+                    <option value="">Select subject</option>
+                </select>
+                <select id="admin-assignment-lecturer" class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3" required>
+                    <option value="">Select lecturer</option>
+                </select>
+                <select id="admin-assignment-responsibility" class="md:col-span-2 w-full rounded-lg border border-gray-300 bg-white px-4 py-3">
+                    <option value="">No responsibility (optional)</option>
+                </select>
+                <div class="md:col-span-2 flex gap-3 justify-end">
+                    <button id="admin-assignment-form-cancel" type="button" class="bg-gray-200 text-gray-900 font-black px-5 py-3 rounded-lg hover:bg-gray-300">Cancel</button>
+                    <button type="submit" class="bg-gray-950 text-white font-black px-5 py-3 rounded-lg hover:bg-sky-700">Save Assignment</button>
+                </div>
+            </form>
+        </section>
+
         <?php include __DIR__ . '/../../Components/FooterBar.php';?>
     </body>
     <script type="module" src="../../JS/main.js"></script>


### PR DESCRIPTION
## Description
Create a new section in the admin panel to assign a subject to a lecturer.
## Changes Made
- Create two new admin sections: `Assign Lecturers to Subjects` and `Manage Lecturer Responsibilities`.
- Create the CRUD API endpoints for each section.
- Create a new table for lecturer responsibilities `lecturer_responsibility` and link this table ID to the `subject_lecture_relations` table.
## Screenshots/Videos
<img width="1713" height="851" alt="Screenshot_10-5-2026_15321_localhost" src="https://github.com/user-attachments/assets/55ac2bf0-3328-44b8-a10a-259cc23a762d" />
<img width="1713" height="851" alt="Screenshot_10-5-2026_153226_localhost" src="https://github.com/user-attachments/assets/8cafa80d-0ac5-4291-9686-94fbbf21ae75" />
<img width="1568" height="608" alt="{4CCCC297-98D7-43C6-BB95-667CFB221B2F}" src="https://github.com/user-attachments/assets/306cbe6e-df69-4240-95fd-a4697fa24e9e" />
<img width="1920" height="1080" alt="Screenshot (10)" src="https://github.com/user-attachments/assets/81e4f6dd-cd14-44e9-8151-964f7b9fe35f" />

## Dependencies/Frameworks
N/A
## Additional Notes
N/A