### PR TITLE
Add responsible_level front end enhansment

### DIFF
--- a/Frontend/JS/admin.js
+++ b/Frontend/JS/admin.js
@@ -2217,6 +2217,7 @@ const initLecturerAssignmentsPanel = () => {
     const responsibilityFormCancel    = document.getElementById('admin-responsibility-form-cancel');
     const responsibilityIdInput       = document.getElementById('admin-responsibility-id');
     const responsibilityNameInput     = document.getElementById('admin-responsibility-name');
+    const responsibilityLevelInput    = document.getElementById('admin-responsibility-level');
 
     const assignmentFormModal         = document.getElementById('admin-assignment-form-modal');
     const assignmentForm              = document.getElementById('admin-assignment-form');
@@ -2263,14 +2264,23 @@ const initLecturerAssignmentsPanel = () => {
                 <thead class="bg-gray-100 uppercase text-gray-600">
                     <tr>
                         <th class="px-4 py-3">Responsibility</th>
+                        <th class="px-4 py-3">Level</th>
                         <th class="px-4 py-3">Created By</th>
                         <th class="px-4 py-3">Action</th>
                     </tr>
                 </thead>
                 <tbody>
-                    ${items.map(item => `
+                    ${items.map(item => {
+                        const level = item.responsible_level;
+                        const levelBadge = (level !== null && level !== undefined && level !== '')
+                            ? `<span class="px-3 py-1 rounded-full text-xs font-black ${Number(level) === 1 ? 'bg-purple-100 text-purple-700' : 'bg-sky-100 text-sky-700'}">
+                                   Level ${escapeHtml(String(level))}${Number(level) === 1 ? ' · In-Charge' : ''}
+                               </span>`
+                            : '<span class="text-gray-400">—</span>';
+                        return `
                         <tr class="border-b border-gray-200">
                             <td class="px-4 py-3 font-bold">${escapeHtml(item.responsibility || '-')}</td>
+                            <td class="px-4 py-3">${levelBadge}</td>
                             <td class="px-4 py-3 text-gray-500">${escapeHtml(item.created_by || '-')}</td>
                             <td class="px-4 py-3">
                                 <div class="flex flex-wrap gap-2">
@@ -2278,8 +2288,8 @@ const initLecturerAssignmentsPanel = () => {
                                     <button type="button" data-responsibility-action="delete" data-responsibility-id="${escapeHtml(item.id)}" class="bg-red-600 text-white px-3 py-2 rounded-lg font-black hover:bg-red-700">Delete</button>
                                 </div>
                             </td>
-                        </tr>
-                    `).join('')}
+                        </tr>`;
+                    }).join('')}
                 </tbody>
             </table>`;
     };
@@ -2312,7 +2322,13 @@ const initLecturerAssignmentsPanel = () => {
                             <td class="px-4 py-3">${escapeHtml(item.subject_name || '-')}</td>
                             <td class="px-4 py-3 font-bold">${escapeHtml(item.lecturer_name || '-')}</td>
                             <td class="px-4 py-3">${item.responsibility_name
-                                ? `<span class="px-3 py-1 rounded-full text-xs font-black bg-sky-100 text-sky-700">${escapeHtml(item.responsibility_name)}</span>`
+                                ? (() => {
+                                    const lvl = item.responsible_level;
+                                    const isInCharge = lvl !== null && lvl !== undefined && Number(lvl) === 1;
+                                    const colorClass = isInCharge ? 'bg-purple-100 text-purple-700' : 'bg-sky-100 text-sky-700';
+                                    const levelPrefix = (lvl !== null && lvl !== undefined) ? `L${escapeHtml(String(lvl))} · ` : '';
+                                    return `<span class="px-3 py-1 rounded-full text-xs font-black ${colorClass}">${levelPrefix}${escapeHtml(item.responsibility_name)}</span>`;
+                                  })()
                                 : '<span class="text-gray-400">—</span>'}</td>
                             <td class="px-4 py-3 text-gray-500">${escapeHtml(item.assigned_by || '-')}</td>
                             <td class="px-4 py-3">
@@ -2331,6 +2347,7 @@ const initLecturerAssignmentsPanel = () => {
     const resetResponsibilityForm = () => {
         responsibilityForm.reset();
         responsibilityIdInput.value = '';
+        if (responsibilityLevelInput) responsibilityLevelInput.value = '';
         responsibilityFormTitle.textContent = 'New Responsibility';
     };
 
@@ -2340,6 +2357,11 @@ const initLecturerAssignmentsPanel = () => {
             responsibilityFormTitle.textContent = 'Update Responsibility';
             responsibilityIdInput.value = record.id || '';
             responsibilityNameInput.value = record.responsibility || '';
+            if (responsibilityLevelInput) {
+                responsibilityLevelInput.value = (record.responsible_level !== null && record.responsible_level !== undefined)
+                    ? String(record.responsible_level)
+                    : '';
+            }
         }
         showModal(responsibilityFormModal);
     };
@@ -2368,8 +2390,15 @@ const initLecturerAssignmentsPanel = () => {
         assignmentLecturerSelect.innerHTML = `<option value="">Select lecturer</option>`
             + lecturers.map(u => `<option value="${escapeHtml(String(u.id))}">${escapeHtml(u.lecturer_name || (u.first_name + ' ' + u.last_name))}</option>`).join('');
 
-        assignmentResponsibilitySelect.innerHTML = `<option value="">No responsibility (optional)</option>`
-            + state.responsibilities.map(r => `<option value="${escapeHtml(String(r.id))}">${escapeHtml(r.responsibility)}</option>`).join('');
+        const leveledResponsibilities = (state.responsibilities || []).filter(
+            r => r.responsible_level !== null && r.responsible_level !== undefined && r.responsible_level !== ''
+        );
+        assignmentResponsibilitySelect.innerHTML = `<option value="">No responsibility</option>`
+            + leveledResponsibilities.map(r => {
+                const lvl = r.responsible_level;
+                const label = `Level ${escapeHtml(String(lvl))}${Number(lvl) === 1 ? ' (In-Charge)' : ''} — ${escapeHtml(r.responsibility)}`;
+                return `<option value="${escapeHtml(String(r.id))}">${label}</option>`;
+            }).join('');
 
         if (record) {
             assignmentFormTitle.textContent = 'Update Assignment';
@@ -2411,9 +2440,11 @@ const initLecturerAssignmentsPanel = () => {
 
     responsibilityForm.addEventListener('submit', async (e) => {
         e.preventDefault();
+        const levelRaw = responsibilityLevelInput?.value?.trim() || '';
         const payload = {
-            id:             responsibilityIdInput.value || '',
-            responsibility: responsibilityNameInput.value.trim(),
+            id:                responsibilityIdInput.value || '',
+            responsibility:    responsibilityNameInput.value.trim(),
+            responsible_level: levelRaw !== '' ? parseInt(levelRaw, 10) : '',
         };
         try {
             const result = payload.id
@@ -2471,6 +2502,41 @@ const initLecturerAssignmentsPanel = () => {
         if (!payload.subject_cord) { window.alert('Please select a subject.'); return; }
         if (!payload.lecturer_id)  { window.alert('Please select a lecturer.'); return; }
 
+        const state = window.__adminStateRef;
+        const existing = state?.assignments || [];
+
+        // Bug 1: same lecturer already assigned to the same subject
+        const duplicateLecturer = existing.find(a =>
+            String(a.subject_cord) === String(payload.subject_cord) &&
+            String(a.lecturer_id)  === String(payload.lecturer_id)  &&
+            String(a.id) !== String(payload.id)
+        );
+        if (duplicateLecturer) {
+            window.alert('This lecturer is already assigned to this subject.\nEach lecturer can only be assigned to a subject once.');
+            return;
+        }
+
+        // Bug 2: a second Level-1 (In-Charge) for the same subject
+        if (payload.responsibility_id) {
+            const selectedResp = (state?.responsibilities || []).find(
+                r => String(r.id) === String(payload.responsibility_id)
+            );
+            if (selectedResp && Number(selectedResp.responsible_level) === 1) {
+                const existingInCharge = existing.find(a =>
+                    String(a.subject_cord) === String(payload.subject_cord) &&
+                    String(a.id) !== String(payload.id) &&
+                    Number(a.responsible_level) === 1
+                );
+                if (existingInCharge) {
+                    window.alert(
+                        'This subject already has a Lecturer In-Charge (Level 1).\n' +
+                        'Remove or update the existing Level 1 assignment first.'
+                    );
+                    return;
+                }
+            }
+        }
+
         try {
             const result = payload.id
                 ? await updateAssignment(payload)
@@ -2482,7 +2548,6 @@ const initLecturerAssignmentsPanel = () => {
             }
             window.alert(result.message || 'Assignment saved.');
             hideAssignmentForm();
-            const state = window.__adminStateRef;
             if (state) await reloadAssignmentData(state);
         } catch (err) {
             window.alert(err.message || 'Failed to save assignment.');

--- a/Frontend/JS/timetable.js
+++ b/Frontend/JS/timetable.js
@@ -728,7 +728,7 @@ const initSchedulingForm = () => {
         setViewText('subject-name', record?.subject || '');
         setViewText('subject-code', record?.subject_cord || record?.lectureId || '');
         setViewText('lecture-in-charge', record?.lecturer_name || '');
-        setViewText('lecture', record?.year || '');
+        setViewText('lecture', record?.other_lecturers || '');
         setViewText('lecture-group', record?.group_name || '');
         setViewText('lab', record?.lab || record?.lab_name || '');
     };

--- a/Frontend/Pages/AdminPanel/admin.php
+++ b/Frontend/Pages/AdminPanel/admin.php
@@ -546,6 +546,10 @@
                 </div>
                 <input type="hidden" id="admin-responsibility-id">
                 <input type="text" id="admin-responsibility-name" placeholder="Responsibility name (e.g. Lab In-Charge)" class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3" required>
+                <div class="flex flex-col gap-1">
+                    <label class="text-xs font-black uppercase tracking-wide text-gray-500">Responsible Level <span class="text-gray-400 font-normal normal-case tracking-normal">(optional — level 1 = Lecturer In-Charge)</span></label>
+                    <input type="number" id="admin-responsibility-level" min="1" placeholder="e.g. 1" class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3">
+                </div>
                 <div class="flex gap-3 justify-end">
                     <button id="admin-responsibility-form-cancel" type="button" class="bg-gray-200 text-gray-900 font-black px-5 py-3 rounded-lg hover:bg-gray-300">Cancel</button>
                     <button type="submit" class="bg-gray-950 text-white font-black px-5 py-3 rounded-lg hover:bg-sky-700">Save Responsibility</button>

--- a/Frontend/Pages/timetable.php
+++ b/Frontend/Pages/timetable.php
@@ -75,7 +75,7 @@
             </section>
 
             <section class="overflow-hidden rounded-lg bg-white/92 shadow-2xl ring-1 ring-white/70">
-                <div class="max-h-[calc(100svh-15rem)] w-full overflow-x-auto overflow-y-auto" style="scrollbar-width: thin;">
+                <div class="max-h-[calc(100svh-15rem)] w-full overflow-x-auto overflow-y-auto pb-10" style="scrollbar-width: thin;">
                     <table id="timetable" class="w-full min-w-[860px] border-separate border-spacing-0 text-sm text-left rtl:text-right">
                         <thead id="timetable-head" class="sticky top-0 z-20"></thead>
                         <tbody id="timetable-body"></tbody>


### PR DESCRIPTION
## Description
Enhance the lecturer responsible assign concept.
## Changes Made
- Update function to assign `responsible_level not equel to 1` lecturer to `#scheduling-form-view`, `#lecture`  removeing year.
- Add a new field to assign the responsible level to the admin panel, Responsibilities, Manage Lecturer Responsibilities.
- Update the function to validate the following concepts
  - Each lecturer can assign one subject at one time with or without responsibility.
  - Each subject has one lecturer with `responsible_level = 1`.
## Screenshots/Videos
<img width="1920" height="1080" alt="{554CC13A-3471-4C6C-BA52-3FDB744695A0}" src="https://github.com/user-attachments/assets/58262c91-cc54-4ec5-8380-68f5b2056acb" />
<img width="1920" height="1080" alt="{94CB5430-7371-4452-B12E-81263C3FBAC4}" src="https://github.com/user-attachments/assets/61faa271-e3b4-42ad-ad71-2683af7b2cc7" />
<img width="760" height="347" alt="{86A4E1E3-9273-40B2-806E-6B9DDBBD3269}" src="https://github.com/user-attachments/assets/27ad80f2-05db-41ac-a74d-2e6572d8edf0" />
<img width="506" height="816" alt="{881A9A0F-9133-430E-ADD8-007F1F130D81}" src="https://github.com/user-attachments/assets/b1cbb8c9-1055-4636-9b82-6e088af8eb32" />

## Dependencies/Frameworks
N/A
## Additional Notes
N/A